### PR TITLE
Update requirements.txt

### DIFF
--- a/collect/requirements.txt
+++ b/collect/requirements.txt
@@ -1,4 +1,4 @@
-MySQL-python==1.2.4
+MySQL-python==1.2.5
 SQLAlchemy==0.8.3
 argparse==1.2.1
 wsgiref==0.1.2


### PR DESCRIPTION
MySQL-python v. 1.2.4 causes a RuntimeError: maximum recursion depth exceeded, which is fixed in v. 1.2.5.
